### PR TITLE
chore: Add new test harness version

### DIFF
--- a/src/main/java/org/jenkinsci/gradle/plugins/jpi/internal/DependencyLookup.java
+++ b/src/main/java/org/jenkinsci/gradle/plugins/jpi/internal/DependencyLookup.java
@@ -39,6 +39,7 @@ public class DependencyLookup {
             case "testCompileOnly":
                 deps.add(new MavenDependency("net.jcip:jcip-annotations:1.0"));
                 deps.add(findbugs);
+                deps.add(servlet);
                 return deps;
             case "generatedJenkinsTestImplementation":
                 deps.addAll(coreSet);

--- a/src/main/java/org/jenkinsci/gradle/plugins/jpi/internal/DependencyLookup.java
+++ b/src/main/java/org/jenkinsci/gradle/plugins/jpi/internal/DependencyLookup.java
@@ -64,13 +64,13 @@ public class DependencyLookup {
     }
 
     private static DependencyFactory findbugsFor(VersionNumber version, boolean beforeBomExists) {
-        String findbugs = "com.github.spotbugs:spotbugs-annotations";
         if (version.compareTo(new VersionNumber("1.618")) < 0) {
-            findbugs = "findbugs:annotations:1.0.0";
+            return new MavenDependency("findbugs:annotations:1.0.0");
         } else if (beforeBomExists) {
-            findbugs = "com.google.code.findbugs:annotations:3.0.0";
+            return new MavenDependency("com.google.code.findbugs:annotations:3.0.0");
+        } else {
+            return new MavenDependency("com.github.spotbugs:spotbugs-annotations");
         }
-        return new MavenDependency(findbugs);
     }
 
     private static DependencyFactory servletFor(VersionNumber version) {
@@ -84,13 +84,14 @@ public class DependencyLookup {
     }
 
     private static DependencyFactory testHarnessFor(VersionNumber version) {
-        String testHarness = "org.jenkins-ci.main:jenkins-test-harness:2112.ve584e0edc63b_";
         if (version.isOlderThan(new VersionNumber("2.64"))) {
-            testHarness = "org.jenkins-ci.main:jenkins-test-harness:2.0";
+            return new MavenDependency( "org.jenkins-ci.main:jenkins-test-harness:2.0");
+        } else if (version.isOlderThanOrEqualTo(new VersionNumber("1.644"))) {
+            return new MavenDependency("org.jenkins-ci.main:jenkins-test-harness:" + version);
+        } else if (version.isOlderThan(new VersionNumber("2.475"))) {
+            return new MavenDependency("org.jenkins-ci.main:jenkins-test-harness:2112.ve584e0edc63b_");
+        } else {
+            return new MavenDependency("org.jenkins-ci.main:jenkins-test-harness:2391.v9b_3e2d3351a_2");
         }
-        if (version.isOlderThanOrEqualTo(new VersionNumber("1.644"))) {
-            testHarness = "org.jenkins-ci.main:jenkins-test-harness:" + version;
-        }
-        return new MavenDependency(testHarness);
     }
 }

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/internal/DependencyLookupSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/internal/DependencyLookupSpec.groovy
@@ -81,11 +81,12 @@ class DependencyLookupSpec extends Specification {
 
         where:
         version                         | expected
-        '1.617'                         | [FINDBUGS_1, JCIP_ANNOTATIONS] as Set
-        '2.150.3'                       | [GOOGLE_FINDBUGS, JCIP_ANNOTATIONS] as Set
-        '2.222.3'                       | [SPOTBUGS, JCIP_ANNOTATIONS] as Set
-        '2.361.2-rc32710.c1a_5e8c179f6' | [SPOTBUGS, JCIP_ANNOTATIONS] as Set
-        '2.369-rc32854.076293e36922'    | [SPOTBUGS, JCIP_ANNOTATIONS] as Set
+        '1.617'                         | [FINDBUGS_1, JCIP_ANNOTATIONS, SERVLET_2_4] as Set
+        '2.150.3'                       | [GOOGLE_FINDBUGS, JCIP_ANNOTATIONS, SERVLET_3_1] as Set
+        '2.222.3'                       | [SPOTBUGS, JCIP_ANNOTATIONS, SERVLET_3_1] as Set
+        '2.361.2-rc32710.c1a_5e8c179f6' | [SPOTBUGS, JCIP_ANNOTATIONS, SERVLET_3_1] as Set
+        '2.369-rc32854.076293e36922'    | [SPOTBUGS, JCIP_ANNOTATIONS, SERVLET_3_1] as Set
+        '2.475'                         | [SPOTBUGS, JCIP_ANNOTATIONS, SERVLET_5_0] as Set
     }
 
     @Unroll


### PR DESCRIPTION
For Jenkins >= 2.475, this gives you test harness 2391.