### PR TITLE
fix: declare testServer dependency on upstream prepareServer

### DIFF
--- a/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/TestServerTask.java
+++ b/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/TestServerTask.java
@@ -211,7 +211,7 @@ public abstract class TestServerTask extends DefaultTask {
                     // Ignore
                 }
                 System.err.println("Timeout reached, terminating Jenkins server");
-                process.destroy();
+                terminateProcessTree(process);
             });
 
             timerThread.start();
@@ -265,16 +265,32 @@ public abstract class TestServerTask extends DefaultTask {
         while ((stdout = stdoutReader.readLine()) != null) {
             System.err.println("    " + stdout);
             if (stdout.contains("Jenkins is fully up and running")) {
-                process.destroy();
+                terminateProcessTree(process);
                 return true;
             }
             if (FAILURE_MESSAGES.stream().anyMatch(stdout::contains)) {
-                process.destroy();
+                terminateProcessTree(process);
                 process.waitFor();
                 throw new GradleException("Jenkins failed to start: " + stdout);
             }
         }
         return false;
+    }
+
+    /**
+     * Terminates the nested build and everything it spawned. The nested build runs
+     * {@code :server} / {@code :hplRun}, which never returns (Jenkins runs until killed), so only
+     * destroying the launched client would leave the Gradle daemon and the Jenkins JVM running —
+     * they reparent to init and accumulate across a test suite until the machine is exhausted.
+     *
+     * <p>The nested build is launched with {@code --no-daemon} precisely so that the build JVM (and
+     * the Jenkins JVM it forks) are descendants of this process and therefore reachable here.
+     * Descendants are destroyed first so nothing is missed when the root exits and its children
+     * would otherwise reparent.
+     */
+    private static void terminateProcessTree(Process process) {
+        process.descendants().forEach(ProcessHandle::destroyForcibly);
+        process.destroyForcibly();
     }
 
     @NotNull
@@ -302,6 +318,10 @@ public abstract class TestServerTask extends DefaultTask {
         List<String> commandLine = new ArrayList<>();
         commandLine.add(getGradleExecutable().get());
         commandLine.add("-Dorg.gradle.java.home=" + getJavaHome().get());
+        // Run without a daemon so the build JVM (and the Jenkins JVM it forks) are descendants of
+        // the launched process. A reused daemon is detached (its parent is init), so it — and the
+        // Jenkins it keeps running — would survive killing the client and leak. See terminateProcessTree.
+        commandLine.add("--no-daemon");
 
         for (var initScriptPath : getInitScriptPaths().get()) {
             commandLine.add("--init-script");

--- a/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/V2JpiPlugin.java
+++ b/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/V2JpiPlugin.java
@@ -210,9 +210,29 @@ public class V2JpiPlugin implements Plugin<Project> {
             var projectByPath = project.getRootProject().getAllprojects().stream()
                     .collect(Collectors.toMap(Project::getPath, it -> it));
             var projectDependencies = getProjectDependencies(runtimeClasspath, projectByPath);
-            configureProjectDependencyJpis(prepareServer, getProjectDependencyJpis(projectDependencies, extension.getArchiveExtension().get()));
-            configureProjectDependencyTasks(prepareRun, getProjectDependencyTasks(projectDependencies, GenerateHplTask.TASK_NAME));
+            var projectDependencyJpis = getProjectDependencyJpis(projectDependencies, extension.getArchiveExtension().get());
+            configureProjectDependencyJpis(prepareServer, projectDependencyJpis);
+            var projectDependencyHplTasks = getProjectDependencyTasks(projectDependencies, GenerateHplTask.TASK_NAME);
+            configureProjectDependencyTasks(prepareRun, projectDependencyHplTasks);
             wireUpstreamJpiReferencedFiles(project, projectDependencies);
+
+            // testServer/testHplRun fingerprint prepareServer/prepareRun's *source*, which resolves
+            // each project-dependency plugin to that upstream module's prepareServer output. The
+            // provider used to read the source (map over Sync::getSource) drops task dependencies, so
+            // declare the upstream prepareServer explicitly. Otherwise Gradle fails implicit-dependency
+            // validation whenever the upstream prepareServer is also scheduled (e.g. two modules'
+            // testServers running together). We depend only on prepareServer — not prepareRun — so the
+            // two upstream prepare tasks (which share workDir/plugins) never run in the same build.
+            var upstreamPrepareServers = projectDependencies.stream()
+                    .filter(dep -> dep.getTasks().getNames().contains("prepareServer"))
+                    .map(dep -> dep.getTasks().named("prepareServer"))
+                    .toList();
+            if (!upstreamPrepareServers.isEmpty()) {
+                project.getTasks().named("testServer", TestServerTask.class,
+                        task -> upstreamPrepareServers.forEach(task::dependsOn));
+                project.getTasks().named("testHplRun", TestServerTask.class,
+                        task -> upstreamPrepareServers.forEach(task::dependsOn));
+            }
         });
 
         project.getTasks().register("server", JavaExec.class, new ServerAction(serverTaskClasspath, projectRoot, workDir, prepareServer));

--- a/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/MultiModuleIntegrationTest.java
+++ b/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/MultiModuleIntegrationTest.java
@@ -139,6 +139,24 @@ class MultiModuleIntegrationTest extends V2IntegrationTestBase {
     }
 
     @Test
+    @Timeout(value = 15, unit = TimeUnit.MINUTES)
+    void concurrentTestServersAcrossModulesDoNotTripValidation() throws IOException {
+        var ith = new IntegrationTestHelper(tempDir, "8.14");
+        configureTwoPluginsForVerification(ith);
+
+        // downstream depends on upstream, so downstream's prepareServer source (which testServer
+        // fingerprints) includes upstream's produced artifacts. Running both testServers together
+        // must not trip Gradle's implicit-dependency validation on the upstream producing task.
+        var result = ith.gradleRunner()
+                .withArguments(":upstream:testServer", ":downstream:testServer")
+                .build();
+
+        assertThat(result.task(":upstream:testServer").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+        assertThat(result.task(":downstream:testServer").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+        assertThat(result.getOutput()).doesNotContain("without declaring an explicit or implicit dependency");
+    }
+
+    @Test
     void multiModuleWithNestedDependenciesShouldLaunchRun() throws IOException, InterruptedException {
         // given
         var ith = new IntegrationTestHelper(tempDir, "8.14");


### PR DESCRIPTION
## Problem

In a multi-module build where one plugin depends on another, running the modules' verification tasks together fails Gradle's implicit-dependency validation:

```
Task ':downstream:testServer' uses this output of task ':upstream:prepareServer'
without declaring an explicit or implicit dependency.
```

`testServer` / `testHplRun` fingerprint `prepareServer` / `prepareRun`'s **source** through a `map(Sync::getSource)` provider, which drops the source's task dependencies. That source resolves each project-dependency plugin to the **upstream module's `prepareServer` output** (the version-dropped `.jpi` synced into the upstream work dir, selected through the downstream `defaultRuntime`). So the task reads a task output with no declared producer, and the build fails whenever that upstream `prepareServer` is also scheduled — e.g. two modules' `testServer`s running at once.

## Change

In the `projectsEvaluated` block, declare `testServer` / `testHplRun` `dependsOn` each project dependency's `prepareServer` (Gradle's own recommended remedy). Only `prepareServer` — never `prepareRun` — so the two upstream prepare tasks, which share `workDir/plugins`, never run in the same build. No-op for single-module builds (no project dependencies → nothing wired).

## Verification

- New regression test `concurrentTestServersAcrossModulesDoNotTripValidation` runs two dependent modules' `testServer` together; both boot with no validation error (fails without this change).
- `MultiModuleIntegrationTest`: the tests exercising this path pass — cross-module reproduction, `server` + `hplRun` launches, and the `testHplRun` upstream-source-change caching test.
- `multiModuleWithNestedDependenciesShouldBuild` fails identically on clean `main` (a pre-existing, unrelated variant-ambiguity in the injected `com.netflix.nebula.archrules.runner` plugin resolving `org.jenkins-ci.plugins:git:5.7.0`); not caused by this change.